### PR TITLE
add unqiue key to getStaticProps

### DIFF
--- a/src/pages/[category].tsx
+++ b/src/pages/[category].tsx
@@ -127,6 +127,7 @@ export const getStaticProps: GetStaticProps<Props, Params> = async (context) => 
   const items = await service.GetItems(categoryId, false)
   return {
     props: {
+      key: categoryId,
       categories,
       category,
       items


### PR DESCRIPTION
Hello, fix #14 bug.
The problem is that page state is not reset after navigation between dynamic routes.
Adding a unique key to getStaticProps will fix the problem.
Please consider looking at this [issue](https://github.com/vercel/next.js/issues/9992).