### PR TITLE
fix scroll bug on mobile view

### DIFF
--- a/src/components/layouts/main.module.scss
+++ b/src/components/layouts/main.module.scss
@@ -13,17 +13,12 @@
   flex-direction: column;
   justify-content: space-between;
   padding-top: $gap-24;
+  gap: $gap-24;
   height: 100vh;
-  -ms-overflow-style: none;
-  scrollbar-width: none;
-  overflow-y: scroll;
+
   @media (max-width: $screen-640) {
     display: none;
   }
-}
-
-.sitenav::-webkit-scrollbar {
-  display: none;
 }
 
 .mobileSitenav {
@@ -36,17 +31,11 @@
     flex-direction: column;
     justify-content: space-between;
     padding-top: $gap-24;
+    gap: $gap-24;
     height: 100vh;
-    -ms-overflow-style: none;
-    scrollbar-width: none;
-    overflow-y: scroll;
     z-index: 100;
     position: absolute;
   }
-}
-
-.mobileSitenav::-webkit-scrollbar {
-  display: none;
 }
 
 .darkModeButton {

--- a/src/components/sitenav.module.scss
+++ b/src/components/sitenav.module.scss
@@ -3,6 +3,14 @@
 .container {
   .sidenav {
     list-style-type: none;
+    height: 100%;
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+    overflow-y: scroll;
+  }
+
+  .sidenav::-webkit-scrollbar {
+    display: none;
   }
 
   .sidenav li {


### PR DESCRIPTION
On mobile view when scrolling, theme switcher position stays fixed

![Screenshot from 2022-03-03 17-02-48](https://user-images.githubusercontent.com/22212139/156579645-c70e72c8-e20d-4587-9249-d606c04f3419.png)

I moved scroll on overflow from sitenav to sidenav.
is it a good approach?

