### PR TITLE
Add Data Union DAO Grants

### DIFF
--- a/content/grants.json
+++ b/content/grants.json
@@ -137,5 +137,14 @@
         "tags": [
             "Longevity"
         ]
+    },
+     {
+        "name": "Data Union DAO Grants",
+        "description": "Data Union DAO is funding builders to build Data Unions using the Data Union SDKs. Visit dataunions.org for more information.",
+        "url": "https://streamr.network/fund/",
+        "tags": [
+            "Data Union"
+            "Data"
+        ]
     }
 ]


### PR DESCRIPTION
please add our grants, our grants page is currently hosted via streamr website (the mother company) that is why I have added our website as information. Thanks!