### PR TITLE
Add boilr3 in starter-kits

### DIFF
--- a/content/starter-kits/boilr3.md
+++ b/content/starter-kits/boilr3.md
@@ -1,0 +1,21 @@
+---
+title: 'boilr3'
+description: 'An open-source all-in-one Next.js + Typescript based dApp boilerplate featuring RainbowKit, TailwindCSS and wagmi.'
+authors: ['@Envoy_1084']
+tags: ['Dapp', 'Web3']
+languages: ['JavaScript']
+url: 'https://github.com/Envoy-VC/boilr3'
+alternateUrl: 'https://boilr3.vercel.app'
+dateAdded: 2023-05-12
+level: 'All'
+---
+
+[boilr3](https://github.com/Envoy-VC/boilr3) is a comprehensive starting point for building decentralized applications using [Next.js](https://nextjs.org/) and [TypeScript](https://www.typescriptlang.org/).
+
+**Tech Stack**
+
+- Next.js
+- TypeScript
+- TailwindCSS
+- RainbowKit
+- wagmi


### PR DESCRIPTION
📝 Description

Added boilr3, a Next.js + TypeScript based dApp boilerplate featuring RainbowKit, TailwindCSS and wagmi in starter-kits section.