### PR TITLE
Add four items from Particle Network

### DIFF
--- a/content/starter-kits/rainbowkit-social-login-boilerplate.md
+++ b/content/starter-kits/rainbowkit-social-login-boilerplate.md
@@ -1,0 +1,16 @@
+---
+title: "RainbowKit Social Login Boilerplate"
+description: "Boilerplate for implementing social login options (via Particle Auth) into RainbowKit."
+authors: ["@TABASCOatw"]
+tags: ["Dapp",]
+languages: ["JavaScript"]
+url: "https://github.com/TABASCOatw/particle-rainbowkit-boilerplate"
+dateAdded: 2024-01-03
+level: "All"
+---
+
+This boilerplate repository provides a simple mechanism for implementing social login options within a RainbowKit modal, creating a familiar environment for users to onboard with their Google account, email, Twitter, phone, etc.
+
+Specifically, this uses Particle Auth (an service from Particle Network) to generate a wallet derived from the social login process, secured using MPC-TSS.
+
+This boilerplate is written in TypeScript and uses RainbowKit (alongside the Particle RainbowKit extension), Wagmi, TypeScript, and Particle Auth.

--- a/content/starter-kits/react-particle-auth-core.md
+++ b/content/starter-kits/react-particle-auth-core.md
@@ -1,0 +1,14 @@
+---
+title: "Social Logins with Particle Auth Core"
+description: "Boilerplate for onboarding users through social login with Particle Auth Core using React."
+authors: ["@TABASCOatw"]
+tags: ["Dapp",]
+languages: ["JavaScript"]
+url: "https://github.com/TABASCOatw/particle-auth-core-demo"
+dateAdded: 2024-01-03
+level: "All"
+---
+
+Particle Auth Core facilitates social logins (through Google, email, Twitter, phone, etc.), onboarding users into either EOA or AA accounts secured by MPC-TSS. This boilerplate acts as a starting point and full demo for implementing Particle Auth Core to achieve this, specifically in-tandem with ERC-4337 account abstraction.
+
+Built using Particle Auth Core, TypeScript, Particle AA SDK.

--- a/content/videos/leveraging-session-keys.md
+++ b/content/videos/leveraging-session-keys.md
@@ -1,0 +1,13 @@
+---
+title: "Creating and Utilizing Session Keys"
+description: "Removing confirmation popups through session keys with Particle Network's AA SDK."
+authors: ["@TABASCOatw"]
+tags: ["Smart Contracts","NFT"]
+languages: ["JavaScript"]
+url: "https://www.youtube.com/watch?v=euOahfA4Vec"
+dateAdded: 2024-01-03
+level: "Intermediate"
+date: 2023-12-20
+---
+
+Session keys are an incredible powerful tool for building consumer-ready applications through their complete removal of popups for end-users. This tutorial leverages Particle Network's AA SDK and Smart Wallet-as-a-Service to showcase the process of implementing session keys (alongside social logins) within your own application (which only takes roughly 7 minutes, around 100 lines of code).

--- a/content/videos/onboarding-with-social-logins.md
+++ b/content/videos/onboarding-with-social-logins.md
@@ -1,0 +1,13 @@
+---
+title: "Onboarding through Social Logins with Particle Network"
+description: "Supercharging UX through Wallet-as-a-Service, exploring three integration scenarios."
+authors: ["@TABASCOatw"]
+tags: ["Dapp", "DevEx"]
+languages: ["JavaScript"]
+url: "https://www.youtube.com/watch?v=PIorEfDWRiE"
+dateAdded: 2024-01-03
+level: "Intermediate"
+date: 2023-11-05
+---
+
+This tutorial walks through three integration scenarios for implementing social logins (via Particle Network) within an application. Specifically, this 12-minute video dives into using Particle Auth, Particle Connect, and Particle Network's `wallet-adapter` integration on Solana. Each of these mechanisms use MPC-TSS to onboard a user within a secure wallet derived from social login, such as Google, Twitter, email, GitHub, etc.


### PR DESCRIPTION
This PR adds four materials from Particle Network's suite of content, largely centered around social logins and account abstraction. Each have been added according to the provided markdown standard - happy to shift anything around if there's something missing though.