### PR TITLE
Change broken link checker frequency

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -4,7 +4,7 @@ on:
   repository_dispatch:
   workflow_dispatch:
   schedule:
-    - cron: "00 18 * * *"
+    - cron: "00 18 * * 1"
 
 jobs:
   linkChecker:


### PR DESCRIPTION
@wslyvh I noticed that the broken link workflow is opening a new issue every day. I propose to run it once a week instead.