### PR TITLE
fix node-guardians.md

### DIFF
--- a/content/code-challenges/node-guardians.md
+++ b/content/code-challenges/node-guardians.md
@@ -20,6 +20,6 @@ We have created a series of coding challenges called “quests” to engage smar
 ### Public Good
 
 Node Guardians is a public good for developers and will always remain so. 
-In addition to supporting the growth of cool ecosystems, we plan to make the platform sustainable by managing [infrastructure)(https://infra.nodeguardians.io/) across various networks.
+In addition to supporting the growth of cool ecosystems, we plan to make the platform sustainable by managing [infrastructure](https://infra.nodeguardians.io/) across various networks.
 
 Rewarding non-contributing operators wastes funds, we prefer community-building and education.

--- a/content/courses/node-guardians.md
+++ b/content/courses/node-guardians.md
@@ -19,6 +19,6 @@ We have created a series of coding challenges called “quests” to engage smar
 ### Public Good
 
 Node Guardians is a public good for developers and will always remain so. 
-In addition to supporting the growth of cool ecosystems, we plan to make the platform sustainable by managing [infrastructure)(https://infra.nodeguardians.io/) across various networks.
+In addition to supporting the growth of cool ecosystems, we plan to make the platform sustainable by managing [infrastructure](https://infra.nodeguardians.io/) across various networks.
 
 Rewarding non-contributing operators wastes funds, we prefer community-building and education.


### PR DESCRIPTION
## Fix link in markdown

A typo in the `node-guardians.md` file is causing the url to be wrongly rendered as we can see in the following screenshot

<img width="515" alt="image" src="https://github.com/wslyvh/useWeb3/assets/61942008/73753cd0-001c-4230-bc26-75db059317ff">

This PR replace the unexpected `)`by a `]`.