### PR TITLE
Add ZeroDay Dev website listing

### DIFF
--- a/content/websites/zeroday-dev.md
+++ b/content/websites/zeroday-dev.md
@@ -1,0 +1,14 @@
+---
+title: "ZeroDay Dev"
+description: "Mobile-first Web3 security learning app with hands-on exploit challenges, guided exercises, and offline study. Free to start, with an optional one-time unlock for full content."
+authors: []
+tags: ["Education", "Security", "Smart Contracts", "Web3"]
+languages: ["Solidity", "Rust"]
+url: "https://apps.apple.com/us/app/zeroday-dev/id6760129673"
+dateAdded: 2026-04-12
+level: "All"
+---
+
+ZeroDay Dev is a mobile-first Web3 security learning app focused on secure coding, exploit analysis, and protocol intuition. It includes hands-on challenges across Solidity, Rust, DeFi, and Solana, plus guided exercises and exam-style practice based on real incidents.
+
+The app is free to start and offers an optional one-time unlock for full content. Its offline-first format makes it useful for short study sessions while still helping learners connect exercises to real exploit records and on-chain case studies.


### PR DESCRIPTION
## Summary
- add `ZeroDay Dev` under `content/websites/` as a new educational Web3 resource listing
- use repo-standard frontmatter fields and slugified filename for catalog ingestion
- note that the app is free to start with an optional one-time unlock for full content

## Test plan
- confirmed the new markdown file follows the existing `content/websites/*.md` schema
- checked editor diagnostics for `content/websites/zeroday-dev.md` and found no lint issues
- could not run `yarn lint` or `yarn build` in this environment because the JS toolchain is not installed (`yarn` and `next` unavailable)