### PR TITLE
Add Web3 bounties overview page

### DIFF
--- a/src/components/bounties.module.scss
+++ b/src/components/bounties.module.scss
@@ -1,0 +1,7 @@
+@use 'assets/styles/variables.scss' as *;
+
+.container {
+  .featured {
+    margin-top: $gap-16;
+  }
+}

--- a/src/components/bounties.tsx
+++ b/src/components/bounties.tsx
@@ -1,0 +1,42 @@
+import { Featured } from 'components/featured'
+import { PanelCard } from 'components/panel'
+import { BountySource } from 'types/bounty'
+import styles from './bounties.module.scss'
+
+interface Props {
+  sources: BountySource[]
+}
+
+export function BountiesOverview(props: Props) {
+  if (!props.sources || props.sources.length === 0) {
+    return null
+  }
+
+  return (
+    <div className={styles.container}>
+      <article>
+        <p>
+          Bounties are a practical way to start contributing to Web3 projects: pick a scoped task, submit the work, and get rewarded when it is
+          accepted.
+        </p>
+        <p>This overview collects platforms that regularly list Web3 bounties, quests, grants, and paid open-source contribution opportunities.</p>
+      </article>
+
+      <Featured className={styles.featured}>
+        {props.sources.map((source) => {
+          return (
+            <PanelCard
+              key={source.url}
+              title={source.title}
+              icon="💸"
+              description={source.description}
+              url={source.url}
+              level={source.level}
+              tags={source.tags}
+            />
+          )
+        })}
+      </Featured>
+    </div>
+  )
+}

--- a/src/components/layouts/header.tsx
+++ b/src/components/layouts/header.tsx
@@ -22,6 +22,7 @@ export const MENU_ITEMS = [
   { url: `/tutorials`, icon: '💻', text: 'Tutorials', category: 'learn' },
   { url: `/videos`, icon: '📺', text: 'Videos', category: 'learn' },
   { url: `/contribute`, icon: '✨', text: 'Contribute', category: 'build' },
+  { url: `/bounties`, icon: '💸', text: 'Bounties', category: 'build' },
   { url: `/earn`, icon: '💸', text: 'Earn', category: 'build' },
   { url: `/grants`, icon: '💰', text: 'Grants', category: 'build' },
   { url: `/starter-kits`, icon: '🏗️', text: 'Templates', category: 'build' },

--- a/src/pages/bounties.tsx
+++ b/src/pages/bounties.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import { ContentItem } from 'types/content-item'
+import { GetStaticProps } from 'next'
+import { Category } from 'types/category'
+import { NavigationProvider } from 'context/navigation'
+import { DEFAULT_REVALIDATE_PERIOD } from 'utils/constants'
+import styles from './pages.module.scss'
+import { MarkdownContentService } from 'services/content'
+import { TopnavLayout } from 'components/layouts/topnav'
+import { SEO } from 'components/SEO'
+import { BountySource } from 'types/bounty'
+import { GetBountySources } from 'services/bounties'
+import { BountiesOverview } from 'components/bounties'
+
+interface Props {
+  categories: Array<Category>
+  items: Array<ContentItem>
+  sources: BountySource[]
+}
+
+export default function Index(props: Props) {
+  return (
+    <NavigationProvider categories={props.categories}>
+      <SEO title="Bounties" divider="💸" description="Find Web3 bounty platforms, quests, grants, and paid open-source contribution opportunities." />
+      <TopnavLayout className={styles.container} title="Web3 Bounties">
+        <BountiesOverview sources={props.sources} />
+      </TopnavLayout>
+    </NavigationProvider>
+  )
+}
+
+export const getStaticProps: GetStaticProps<Props> = async () => {
+  const service = new MarkdownContentService()
+  const items = await service.GetItems('', true)
+  const categories = await service.GetCategories()
+
+  return {
+    props: {
+      items,
+      categories,
+      sources: GetBountySources(),
+    },
+    revalidate: DEFAULT_REVALIDATE_PERIOD,
+  }
+}

--- a/src/services/bounties.ts
+++ b/src/services/bounties.ts
@@ -1,0 +1,54 @@
+import { BountySource } from 'types/bounty'
+
+export function GetBountySources(): BountySource[] {
+  return [
+    {
+      title: 'Gitcoin Bounties',
+      description: 'Explore open Web3 bounties from Gitcoin and find tasks across ecosystems, protocols, and developer tooling.',
+      url: 'https://bounties.gitcoin.co/explorer',
+      tags: ['Bounties', 'Open Source', 'Ethereum'],
+      level: 'Beginner',
+      platform: 'Gitcoin',
+    },
+    {
+      title: 'Dework Bounties',
+      description: 'Discover DAO tasks, contribution boards, and bounty opportunities from Web3 communities using Dework.',
+      url: 'https://app.dework.xyz/bounties',
+      tags: ['DAO', 'Bounties', 'Community'],
+      level: 'Beginner',
+      platform: 'Dework',
+    },
+    {
+      title: 'Layer3 Quests',
+      description: 'Complete curated Web3 quests and campaigns to learn protocols while earning rewards and credentials.',
+      url: 'https://layer3.xyz/quests',
+      tags: ['Quests', 'Rewards', 'Learning'],
+      level: 'Beginner',
+      platform: 'Layer3',
+    },
+    {
+      title: 'Questbook Grants',
+      description: 'Browse grant programs and funded contribution opportunities from Web3 ecosystems and protocols.',
+      url: 'https://questbook.app/',
+      tags: ['Grants', 'Bounties', 'Funding'],
+      level: 'Intermediate',
+      platform: 'Questbook',
+    },
+    {
+      title: 'OnlyDust',
+      description: 'Find open-source Web3 projects that reward contributors for issues, pull requests, and ongoing maintenance.',
+      url: 'https://app.onlydust.com/projects',
+      tags: ['Open Source', 'Bounties', 'Contribute'],
+      level: 'Intermediate',
+      platform: 'OnlyDust',
+    },
+    {
+      title: 'Superteam Earn',
+      description: 'Browse crypto bounties, grants, and freelance opportunities from the Superteam ecosystem.',
+      url: 'https://earn.superteam.fun/',
+      tags: ['Bounties', 'Freelance', 'Solana'],
+      level: 'Intermediate',
+      platform: 'Superteam',
+    },
+  ]
+}

--- a/src/types/bounty.ts
+++ b/src/types/bounty.ts
@@ -1,0 +1,8 @@
+export interface BountySource {
+  title: string
+  description: string
+  url: string
+  tags: string[]
+  level: 'All' | 'Beginner' | 'Intermediate' | 'Advanced'
+  platform: string
+}


### PR DESCRIPTION
## Summary
- Add a `/bounties` page that lists Web3 bounty, quest, grant, and paid open-source contribution platforms.
- Reuse the existing top navigation layout, featured grid, and panel card components for consistency with the contribution pages.
- Add a Build menu entry so visitors can discover the new bounties overview.

## Validation
- `./node_modules/.bin/prettier --check src/components/layouts/header.tsx src/components/bounties.tsx src/components/bounties.module.scss src/pages/bounties.tsx src/services/bounties.ts src/types/bounty.ts`
- `npx tsc --noEmit`
- `git diff --check -- src/components/layouts/header.tsx src/components/bounties.tsx src/components/bounties.module.scss src/pages/bounties.tsx src/services/bounties.ts src/types/bounty.ts`

Note: `next build --no-lint` reaches the existing `/contribute` GitHub API data collection path and requires a valid `ISSUES_GITHUB_TOKEN`; with a dummy token it fails before completing page data collection.