### PR TITLE
content: add OpenChainBench website resource

### DIFF
--- a/content/websites/openchainbench.md
+++ b/content/websites/openchainbench.md
@@ -1,0 +1,12 @@
+---
+title: 'OpenChainBench'
+description: 'Live, neutral benchmarks for crypto infrastructure: RPC latency across 22 EVM chains and Solana, oracle deviation, bridge quote fees, perp DEX all-in cost, gas oracle accuracy'
+authors: []
+tags: ['Ethereum', 'Infrastructure']
+languages: []
+url: 'https://openchainbench.com'
+dateAdded: 2026-07-14
+level: 'Intermediate'
+---
+
+Open, reproducible benchmarks for crypto infrastructure. Public no-key RPC endpoints across 22 EVM chains plus Solana are probed from three regions every minute, with p50, p95 and p99 latency published under CC BY 4.0. Additional benches cover oracle deviation, bridge quote latency, perp DEX all-in cost, gas oracle accuracy, prediction market resolution delay, and Hyperliquid builder revenue. JSON API, OpenAPI 3.1 spec, and MCP server available for programmatic use.


### PR DESCRIPTION
## Summary

Adds a new website resource entry at `content/websites/openchainbench.md` for OpenChainBench, an open benchmark for crypto infrastructure.

## About the resource

OpenChainBench probes public no-key RPC endpoints across 22 EVM chains plus Solana from three regions every minute, and publishes p50, p95 and p99 latency along with oracle deviation, bridge quote latency, perp DEX all-in cost, gas oracle accuracy, prediction market resolution delay, and Hyperliquid builder revenue. Open methodology, CC BY 4.0 data, JSON API, OpenAPI spec, and MCP server available.

- Homepage: https://openchainbench.com
- Methodology: https://openchainbench.com/methodology

Frontmatter uses the same schema as existing resources under `content/websites/`. Level set to `Intermediate`, tagged with `Ethereum` and `Infrastructure`.

## Test plan

- [x] Frontmatter matches existing website entries
- [x] No changes to any other file
- [x] External links verified